### PR TITLE
use etcher instructions

### DIFF
--- a/beaglebone.coffee
+++ b/beaglebone.coffee
@@ -20,7 +20,7 @@ module.exports =
 
 	instructions:
 		windows: [
-			instructions.WINDOWS_DISK_IMAGER_SD
+			instructions.WINDOWS_ETCHER_SD
 			instructions.EJECT_SD
 			instructions.FLASHER_WARNING
 			BBB_FLASH
@@ -29,9 +29,7 @@ module.exports =
 			instructions.BOARD_REPOWER
 		]
 		osx: [
-			instructions.OSX_PLUG_SD
-			instructions.OSX_UNMOUNT_SD
-			instructions.DD_BURN_IMAGE_SD
+			instructions.OSX_ETCHER_SD
 			instructions.EJECT_SD
 			instructions.FLASHER_WARNING
 			BBB_FLASH
@@ -40,8 +38,7 @@ module.exports =
 			instructions.BOARD_REPOWER
 		]
 		linux: [
-			instructions.LINUX_DF_SD
-			instructions.DD_BURN_IMAGE_SD
+			instructions.LINUX_ETCHER_SD
 			instructions.EJECT_SD
 			instructions.FLASHER_WARNING
 			BBB_FLASH


### PR DESCRIPTION
This makes the instructions use Etcher as primary image burning software.

To make it work:
1. approve and merge https://github.com/resin-io/resin-device-types/pull/7
2. update the `resin-device-types` submodule in this branch and update this PR
3. test how the JSON file is built (I've tested it myself by checking out the corresponding branch in a submodule)
4. approve and merge this PR
5. follow the standard procedure to release this device type and get it to img-maker

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-os/resin-beaglebone/4)
<!-- Reviewable:end -->
