### PR TITLE
use simplified etcher instructions

### DIFF
--- a/beaglebone.coffee
+++ b/beaglebone.coffee
@@ -4,6 +4,12 @@ deviceTypesCommon = require 'resin-device-types/common'
 BBB_FLASH = 'Power up the <%= TYPE_NAME %> while holding down the small button near the SD slot.
 You need to keep it pressed until the blue LEDs start flashing wildly.'
 
+postProvisioningInstruction = [
+	instructions.BOARD_SHUTDOWN
+	instructions.REMOVE_INSTALL_MEDIA
+	instructions.BOARD_REPOWER
+]
+
 module.exports =
 	slug: 'beaglebone-black'
 	aliases: [ 'beaglebone' ]
@@ -12,40 +18,14 @@ module.exports =
 	state: 'released'
 
 	stateInstructions:
-		postProvisioning: [
-			instructions.BOARD_SHUTDOWN
-			instructions.REMOVE_INSTALL_MEDIA
-			instructions.BOARD_REPOWER
-		]
+		postProvisioning: postProvisioningInstruction
 
-	instructions:
-		windows: [
-			instructions.WINDOWS_ETCHER_SD
-			instructions.EJECT_SD
-			instructions.FLASHER_WARNING
-			BBB_FLASH
-			instructions.BOARD_SHUTDOWN
-			instructions.REMOVE_INSTALL_MEDIA
-			instructions.BOARD_REPOWER
-		]
-		osx: [
-			instructions.OSX_ETCHER_SD
-			instructions.EJECT_SD
-			instructions.FLASHER_WARNING
-			BBB_FLASH
-			instructions.BOARD_SHUTDOWN
-			instructions.REMOVE_INSTALL_MEDIA
-			instructions.BOARD_REPOWER
-		]
-		linux: [
-			instructions.LINUX_ETCHER_SD
-			instructions.EJECT_SD
-			instructions.FLASHER_WARNING
-			BBB_FLASH
-			instructions.BOARD_SHUTDOWN
-			instructions.REMOVE_INSTALL_MEDIA
-			instructions.BOARD_REPOWER
-		]
+	instructions: [
+		instructions.ETCHER_SD
+		instructions.EJECT_SD
+		instructions.FLASHER_WARNING
+		BBB_FLASH
+	].concat(postProvisioningInstruction)
 
 	gettingStartedLink:
 		windows: 'http://docs.resin.io/#/pages/installing/gettingStarted-BBB.md#windows'


### PR DESCRIPTION
It uses https://github.com/resin-io/resin-device-types/pull/8

What's in this PR:
- we agreed to use the link to the etcher home page instead of the direct download link
- now we don't need os-specific instructions altogether
- I've also demonstrated that as our normal instructions end with post-provisioning instructions we can remove duplication and use the power of real programming language

As with https://github.com/resin-io/resin-device-types/pull/8 I'm going to merge this right now (I've tested the build locally). Again blame me and ping me if you don't like something.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-os/resin-beaglebone/6)
<!-- Reviewable:end -->
