### PR TITLE
Custom docker images in connectable builds on resin-beaglebone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Custom docker images in connectable builds [Andrei]
 * Bump meta-resin to include connectable builds [Andrei]
 * Add support for optional supervisor image [Andrei]
 * Update meta-resin to v1.2 [Andrei]

--- a/layers/meta-resin-beaglebone/recipes-containers/docker-disk/docker-resin-supervisor-disk.bbappend
+++ b/layers/meta-resin-beaglebone/recipes-containers/docker-disk/docker-resin-supervisor-disk.bbappend
@@ -1,2 +1,2 @@
-TARGET_REPOSITORY_beaglebone = "resin/armv7hf-supervisor"
+SUPERVISOR_REPOSITORY_beaglebone = "resin/armv7hf-supervisor"
 LED_FILE_beaglebone = "/sys/class/leds/beaglebone\:green\:usr3/brightness"


### PR DESCRIPTION
Connects to resin-os/meta-resin#133-supervisor-custom-image-tag
@telphan @floion