### PR TITLE
linux-beagleboard: don't set kernel module compression here

### DIFF
--- a/layers/meta-resin-beaglebone/recipes-kernel/linux/linux-beagleboard_4.4.bb
+++ b/layers/meta-resin-beaglebone/recipes-kernel/linux/linux-beagleboard_4.4.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "Linux kernel for beaglebone boards"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 
-inherit kernel kernel-resin compress-kernel-modules
+inherit kernel kernel-resin
 
 require recipes-kernel/linux/linux-dtb.inc
 require recipes-kernel/linux/setup-defconfig.inc


### PR DESCRIPTION
Module compression is now enabled globaly in "kernel-resin".

connect resin-os/meta-resin#303