### PR TITLE
linux-beaglebone: disable kernel module compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Don't compress kernel modules [Michal]
+
 # v2.0.0-beta.1 - 2016-10-11
 
 * Update meta-resin to v2.0-beta.1 [Andrei]

--- a/layers/meta-resin-beaglebone/recipes-kernel/linux/linux-beagleboard_4.4.bb
+++ b/layers/meta-resin-beaglebone/recipes-kernel/linux/linux-beagleboard_4.4.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "Linux kernel for beaglebone boards"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 
-inherit kernel kernel-resin compress-kernel-modules
+inherit kernel kernel-resin
 
 require recipes-kernel/linux/linux-dtb.inc
 require recipes-kernel/linux/setup-defconfig.inc


### PR DESCRIPTION
This causes problems if people try to modprobe from within their
containers based on either Debian or Ubuntu.

Connects to https://github.com/resin-os/resinos/issues/89