### PR TITLE
u-boot: only a predefined key can delay or abort boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Set a predefined sequence to abort or delay booting [Michal]
+
 # v2.0.0-beta.3 - 2016-11-07
 
 * Update meta-resin to v2.0-beta.3 [Andrei]

--- a/layers/meta-resin-beaglebone/recipes-bsp/u-boot/u-boot-ti-staging/0005-Autoboot-keyboard-beaglebone-fixes.patch
+++ b/layers/meta-resin-beaglebone/recipes-bsp/u-boot/u-boot-ti-staging/0005-Autoboot-keyboard-beaglebone-fixes.patch
@@ -1,0 +1,43 @@
+From ca7b7f00c70389f5f8cfbe151873c6d83d32d64b Mon Sep 17 00:00:00 2001
+From: codewithpassion <dominik.fretz@gmail.com>
+Date: Fri, 2 Oct 2015 17:54:45 -0700
+Subject: [PATCH] Adding autoboot for BBB as described in
+ http://www.mikini.dk/index.php/category/beaglebone-black/boot-issue
+
+Signed-off-by: Michal Mazurek <michal@resin.io>
+
+Upstream-Status: Configuration
+
+---
+ include/configs/ti_am335x_common.h | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/include/configs/ti_am335x_common.h b/include/configs/ti_am335x_common.h
+index 9697431..aa6c572 100644
+--- a/include/configs/ti_am335x_common.h
++++ b/include/configs/ti_am335x_common.h
+@@ -12,6 +12,13 @@
+ #ifndef __CONFIG_TI_AM335X_COMMON_H__
+ #define __CONFIG_TI_AM335X_COMMON_H__
+ 
++#define CONFIG_AUTOBOOT_KEYED
++#define CONFIG_AUTOBOOT_DELAY_STR " "
++#define CONFIG_AUTOBOOT_STOP_STR "stop"
++#define CONFIG_AUTOBOOT_PROMPT "autoboot in %d seconds (type \"%s\" to abort or \"%s\" to delay)\n",bootdelay,CONFIG_AUTOBOOT_STOP_STR,CONFIG_AUTOBOOT_DELAY_STR
++#define CONFIG_BOOT_RETRY_TIME 15
++#define CONFIG_RESET_TO_RETRY
++
+ #define CONFIG_AM33XX
+ #define CONFIG_ARCH_CPU_INIT
+ #define CONFIG_SYS_CACHELINE_SIZE       64
+@@ -96,4 +103,7 @@
+ /* Now bring in the rest of the common code. */
+ #include <configs/ti_armv7_omap.h>
+ 
++#undef  CONFIG_BOOTDELAY
++#define CONFIG_BOOTDELAY               1
++
+ #endif	/* __CONFIG_TI_AM335X_COMMON_H__ */
+-- 
+1.9.1
+

--- a/layers/meta-resin-beaglebone/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
+++ b/layers/meta-resin-beaglebone/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
@@ -2,6 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI_append = " \
     file://0002-am335x_evm.h-Set-not-env-if-CONFIG_EMMC_BOOT.patch \
     file://0001-ti_armv7_common.h-Don-t-hardcode-dev-0-but-use-mmcde.patch \
+    file://0005-Autoboot-keyboard-beaglebone-fixes.patch \
     file://uEnv.txt_internal \
     "
 


### PR DESCRIPTION
connect https://github.com/resin-os/resinos/issues/80
