### PR TITLE
Set wifi MAC address based on the contents of the EEPROM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Set wlan0 MAC address to EEPROM value [Will]
+
 # v2.0.2+rev2 - 2017-05-01
 
 * Bump resin-yocto-scripts to fix Jenkins deployment [Andrei]

--- a/layers/meta-resin-beaglebone/recipes-connectivity/bb-wl18xx-wlan0/bb-wl18xx-wlan0.bb
+++ b/layers/meta-resin-beaglebone/recipes-connectivity/bb-wl18xx-wlan0/bb-wl18xx-wlan0.bb
@@ -1,0 +1,21 @@
+DESCRIPTION = "Set wifi MAC address"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${RESIN_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = " \
+	file://bb-wl18xx-wlan0 \
+	file://bb-wl18xx-wlan0.service \
+"
+
+inherit allarch systemd
+
+RDEPENDS_${PN} = "bash"
+
+do_install() {
+	install -d ${D}/usr/bin
+	install -m 0755 ${WORKDIR}/bb-wl18xx-wlan0 ${D}/usr/bin/bb-wl18xx-wlan0
+	install -d ${D}${systemd_unitdir}/system
+	install -m 0644 ${WORKDIR}/bb-wl18xx-wlan0.service ${D}${systemd_unitdir}/system
+}
+
+SYSTEMD_SERVICE_${PN} = "bb-wl18xx-wlan0.service"

--- a/layers/meta-resin-beaglebone/recipes-connectivity/bb-wl18xx-wlan0/files/bb-wl18xx-wlan0
+++ b/layers/meta-resin-beaglebone/recipes-connectivity/bb-wl18xx-wlan0/files/bb-wl18xx-wlan0
@@ -1,0 +1,114 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2016-2017 Robert Nelson <robertcnelson@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# Modified by willn@resin.io to set the MAC address on the interface rather than
+# modify the firmware (our rootfs is read only). Original at:
+#  https://github.com/rcn-ee/repos/tree/master/bb-wl18xx-firmware/suite/jessie/debian
+
+IFACE=wlan0
+
+set_wlan_0_mac () {
+        ip link set dev "$IFACE" address $wlan_0_mac
+}
+
+set_wlan_0_mac_from_eeprom () {
+	if [ -f ${eeprom} ] ; then
+		wlan_0_mac=$(hexdump -e '8/1 "%c"' ${eeprom} -n 72 | tail -1 | cut -b 5-8 || true)
+		if [ ! "x${wlan_0_mac}" = "xA335" ] ; then
+			wlan_0_mac=$(hexdump -e '8/1 "%c"' ${eeprom} -n 72 | tail -1 | cut -b 5-16 | sed 's/\(..\)/\1:/g;s/:$//' | awk '{print toupper($0)}' || true)
+		else
+		        echo "Could not read valid MAC from EEPROM"
+		        exit
+		fi
+	else
+	        echo "Could not read MAC from EEPROM: $eeprom"
+	        exit
+	fi
+
+	echo "wlan_0_mac=[${wlan_0_mac}]"
+	set_wlan_0_mac
+}
+
+set_wlan_0_mac_from_cpsw_0 () {
+	mac_address="/proc/device-tree/ocp/ethernet@4a100000/slave@4a100200/mac-address"
+	if [ -f ${mac_address} ] ; then
+		cpsw_0_mac=$(hexdump -v -e '1/1 "%02X" ":"' ${mac_address} | sed 's/.$//' | awk '{print toupper($0)}')
+        else
+	        echo "Could not read MAC from CPSW0: $mac_address"
+	        exit
+	fi
+	wlan_0_mac="${cpsw_0_mac}"
+	echo "wlan_0_mac=[${wlan_0_mac}]"
+	set_wlan_0_mac
+}
+
+set_wlan_0_mac_from_cpsw_4 () {
+	mac_address="/proc/device-tree/ocp/ethernet@4a100000/slave@4a100200/mac-address"
+	if [ -f ${mac_address} ] ; then
+		cpsw_0_mac=$(hexdump -v -e '1/1 "%02X" ":"' ${mac_address} | sed 's/.$//' | awk '{print toupper($0)}')
+	else
+	        echo "Could not read MAC from CPSW4: $mac_address"
+	        exit
+	fi
+
+	if [ -f /usr/bin/bc ] ; then
+		mac_0_prefix=$(echo ${cpsw_0_mac} | cut -c 1-14)
+
+		cpsw_0_6=$(echo ${cpsw_0_mac} | awk -F ':' '{print $6}')
+		#bc cuts off leading zero's, we need ten/ones value
+		cpsw_res=$(echo "obase=16;ibase=16;$cpsw_0_6 + 104" | bc)
+
+		cpsw_4_mac=${mac_0_prefix}:$(echo ${cpsw_res} | cut -c 2-3)
+	else
+	        echo "Could not find bc"
+	        exit
+	fi
+	wlan_0_mac="${cpsw_4_mac}"
+	echo "wlan_0_mac=[${wlan_0_mac}]"
+	set_wlan_0_mac
+}
+
+board=$(cat /proc/device-tree/model | sed "s/ /_/g" | tr -d '\000')
+case "${board}" in
+TI_AM335x_BeagleBone_Green_Wireless)
+	eeprom="/sys/bus/i2c/devices/0-0050/eeprom"
+	set_wlan_0_mac_from_eeprom
+	#make sure wl18xx_wl_en is on...
+	if [ -f /sys/class/leds/wl18xx_wl_en/brightness ] ; then
+		echo 1 > /sys/class/leds/wl18xx_wl_en/brightness || true
+	fi
+	;;
+TI_AM335x_BeagleBone_Black_Wireless)
+	set_wlan_0_mac_from_cpsw_0
+	;;
+TI_AM335x_BeagleBone_Black_Wireless_RoboticsCape)
+	set_wlan_0_mac_from_cpsw_0
+	;;
+TI_AM335x_BeagleBone_Blue)
+	set_wlan_0_mac_from_cpsw_0
+	;;
+TI_AM335x_BeagleBone_Black_Gateway_Cape)
+	set_wlan_0_mac_from_cpsw_4
+	;;
+*)
+	;;
+esac

--- a/layers/meta-resin-beaglebone/recipes-connectivity/bb-wl18xx-wlan0/files/bb-wl18xx-wlan0.service
+++ b/layers/meta-resin-beaglebone/recipes-connectivity/bb-wl18xx-wlan0/files/bb-wl18xx-wlan0.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=BB WL18xx wlan0 Service
+Before=network-pre.target
+Wants=network-pre.target
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/bb-wl18xx-wlan0
+
+[Install]
+WantedBy=multi-user.target

--- a/layers/meta-resin-beaglebone/recipes-core/images/resin-image.bbappend
+++ b/layers/meta-resin-beaglebone/recipes-core/images/resin-image.bbappend
@@ -1,3 +1,3 @@
 include resin-image.inc
 
-IMAGE_INSTALL_append_beaglebone = " bb-org-overlays fix-mmc-bbb"
+IMAGE_INSTALL_append_beaglebone = " bb-org-overlays fix-mmc-bbb bb-wl18xx-wlan0"


### PR DESCRIPTION
This is an attempt to fix https://github.com/resin-os/resinos/issues/133

The MAC address for the wifi interface is stored in the EEPROM and needs to be set at boot, otherwise it remains DE:AD:BE:EF:00:00