### PR TITLE
Add a fix for mmc page allocation failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Add a fix for mmc page alloc failures under load [Will]
 * Update resin-yocto-scripts to master [Will]
 
 # v1.26.0-rc0 - 2017-01-27

--- a/layers/meta-resin-beaglebone/recipes-kernel/linux/linux-beagleboard-4.4/0001-omap_hsmmc-Reduce-max_segs.patch
+++ b/layers/meta-resin-beaglebone/recipes-kernel/linux/linux-beagleboard-4.4/0001-omap_hsmmc-Reduce-max_segs.patch
@@ -1,0 +1,36 @@
+From fb8ec188334f571e835115a0deb7b5be8662bb38 Mon Sep 17 00:00:00 2001
+From: Will Newton <willn@resin.io>
+Date: Fri, 16 Jun 2017 12:13:21 +0200
+Subject: [PATCH] omap_hsmmc: Reduce max_segs
+
+Reduce max_segs to a value that allows allocation of an entire
+descriptor list within a single page. This avoids doing a
+higher order GFP_ATOMIC allocation when setting up a transfer
+which can potentially fail and lead to I/O failures.
+
+Upstream-Status: Pending
+Signed-off-by: Will Newton <willn@resin.io>
+---
+ drivers/mmc/host/omap_hsmmc.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/mmc/host/omap_hsmmc.c b/drivers/mmc/host/omap_hsmmc.c
+index 1438a72..d5f42d9 100644
+--- a/drivers/mmc/host/omap_hsmmc.c
++++ b/drivers/mmc/host/omap_hsmmc.c
+@@ -2864,9 +2864,9 @@ static int omap_hsmmc_probe(struct platform_device *pdev)
+ 			host->use_adma = true;
+ 	}
+ 
+-	/* Since we do only SG emulation, we can have as many segs
+-	 * as we want. */
+-	mmc->max_segs = 1024;
++	/* Set this to a value that allows allocating an entire descriptor
++	   list within a page (zero order allocation). */
++	mmc->max_segs = 64;
+ 
+ 	mmc->max_blk_size = 512;       /* Block Length at max can be 1024 */
+ 	mmc->max_blk_count = 0xFFFF;    /* No. of Blocks is 16 bits */
+-- 
+2.7.4
+

--- a/layers/meta-resin-beaglebone/recipes-kernel/linux/linux-beagleboard_4.4.bb
+++ b/layers/meta-resin-beaglebone/recipes-kernel/linux/linux-beagleboard_4.4.bb
@@ -50,4 +50,5 @@ KERNEL_GIT_PROTOCOL = "git"
 SRC_URI += " \
     ${KERNEL_GIT_URI};protocol=${KERNEL_GIT_PROTOCOL};tag=${TAG};nobranch=1 \
     file://defconfig \
+    file://0001-omap_hsmmc-Reduce-max_segs.patch \
     "


### PR DESCRIPTION

The default maximum value for the number of segments in the MMC driver is too high. Set it to something more reasonable to avoid failing allocations under load.
