### PR TITLE
bb-org-overlays: Add overlays for being able to use CAN0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Add overlays for being able to use the CAN interface on P9 pins 19 and 20 (CAN0) [Florin]
+
 # v2.7.5+rev1
 ## (2017-11-01)
 

--- a/layers/meta-resin-beaglebone/recipes-kernel/linux/bb-org-overlays.bb
+++ b/layers/meta-resin-beaglebone/recipes-kernel/linux/bb-org-overlays.bb
@@ -11,6 +11,8 @@ SRCREV = "b5846ff2b7c903e2d702b8b9bd7106961baee6dd"
 SRC_URI = " \
     git://github.com/beagleboard/bb.org-overlays.git \
     file://0001-Do-not-use-absolute-path-for-the-dtc-binary.patch \
+    file://BB-CAN0-00A0.dts \
+    file://BB-I2C2N-00A0.dts \
     file://SDS-CAPE-00A0.dts \
     "
 
@@ -22,6 +24,8 @@ PACKAGES = "${PN}"
 FILES_${PN} += "/lib/firmware"
 
 do_compile_prepend () {
+    cp ${WORKDIR}/BB-CAN0-00A0.dts ${S}/src/arm/
+    cp ${WORKDIR}/BB-I2C2N-00A0.dts ${S}/src/arm/
     cp ${WORKDIR}/SDS-CAPE-00A0.dts ${S}/src/arm/
 }
 

--- a/layers/meta-resin-beaglebone/recipes-kernel/linux/bb-org-overlays/BB-CAN0-00A0.dts
+++ b/layers/meta-resin-beaglebone/recipes-kernel/linux/bb-org-overlays/BB-CAN0-00A0.dts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015 Robert Nelson <robertcnelson@gmail.com>
+ *
+ * Virtual cape for CAN0 on connector pins P9.19 P9.20
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/board/am335x-bbw-bbb-base.h>
+#include <dt-bindings/pinctrl/am33xx.h>
+
+/ {
+	compatible = "ti,beaglebone", "ti,beaglebone-black", "ti,beaglebone-green";
+
+	/* identification */
+	part-number = "BB-CAN0";
+	version = "00A0";
+
+	/* state the resources this cape uses */
+	exclusive-use =
+		/* the pin header uses */
+		"P9.19",	/* dcan0_rx */
+		"P9.20",	/* dcan0_tx */
+		/* the hardware ip uses */
+		"dcan0";
+
+	fragment@0 {
+		target = <&am33xx_pinmux>;
+		__overlay__ {
+			bb_dcan0_pins: pinmux_dcan0_pins {
+				pinctrl-single,pins = <
+					BONE_P9_19 (PIN_INPUT_PULLUP | MUX_MODE2) /* i2c2_scl.d_can0_rx */
+					BONE_P9_20 (PIN_OUTPUT_PULLUP | MUX_MODE2) /* i2c2_sda.d_can0_tx */
+				>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&dcan0>;
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <&bb_dcan0_pins>;
+		};
+	};
+};

--- a/layers/meta-resin-beaglebone/recipes-kernel/linux/bb-org-overlays/BB-I2C2N-00A0.dts
+++ b/layers/meta-resin-beaglebone/recipes-kernel/linux/bb-org-overlays/BB-I2C2N-00A0.dts
@@ -1,0 +1,24 @@
+/*
+ * Virtual cape for disabling I2C2
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "ti,beaglebone", "ti,beaglebone-black", "ti,beaglebone-green";
+
+	/* identification */
+	part-number = "BB-I2C2N";
+	version = "00A0";
+
+	fragment@0 {
+		target = <&i2c2>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};


### PR DESCRIPTION
We add the device tree overlay which does the pinmuxing for using the CAN interface
from P9 pins 19 and 20.
However, the current .dtb we use enables I2C2 on those particular pins so before we
are able to load this overlay we need to also disable I2C2 (by using the BB-I2C2N-00A0 overlay).

First disable I2C2 and then enable CAN0:

Signed-off-by: Florin Sarbu <florin@resin.io>