### PR TITLE
linux-beaglebone: Compile additional device tree

### DIFF
--- a/layers/meta-resin-beaglebone/recipes-kernel/linux/linux-beagleboard_4.14.bb
+++ b/layers/meta-resin-beaglebone/recipes-kernel/linux/linux-beagleboard_4.14.bb
@@ -13,7 +13,7 @@ DEPENDS += "lzop-native"
 # Look in the generic major.minor directory for files
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-4.14:"
 
-KERNEL_DEVICETREE_beaglebone = "am335x-bone.dtb am335x-boneblack.dtb am335x-boneblack-wireless.dtb am335x-boneblue.dtb am335x-bonegreen.dtb am335x-bonegreen-wireless.dtb"
+KERNEL_DEVICETREE_beaglebone = "am335x-bone.dtb am335x-boneblack.dtb am335x-boneblack-wireless.dtb am335x-boneblue.dtb am335x-bonegreen.dtb am335x-bonegreen-wireless.dtb am335x-boneblack-emmc-overlay.dtb"
 
 KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
 


### PR DESCRIPTION
Add the am335x-boneblack-emmc-overlay.dtb file to the list of
compiled dtbs

Changelog-entry: linux-beaglebone: Add am335x-boneblack-emmc-overlay.dtb to the list of compiled dtbs
Signed-off-by: Sebastian Panceac <sebastian@resin.io>